### PR TITLE
fix metrics path to be /metrics not /metrics/

### DIFF
--- a/pgme.go
+++ b/pgme.go
@@ -1,28 +1,26 @@
 package main
 
 import (
-    "bytes"
-    "context"
-    "encoding/csv"
-    "fmt"
-    "html/template"
-    "net/http"
-    "log"
-    "os"
-    "os/exec"
-    "strings"
-	"syscall"
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
 	"os/signal"
 	"path"
+	"strings"
+	"syscall"
 )
 
-
 type PageVariables struct {
-	PageTitle        string
-	Metrics			 []string
-	VersionInfo      map[string]string
+	PageTitle   string
+	Metrics     []string
+	VersionInfo map[string]string
 }
-
 
 var (
 	// BuildTime is a time label of the moment when the binary was built
@@ -42,18 +40,16 @@ func getEnv(key, fallback string) string {
 	return value
 }
 
-
 // healthz is a liveness probe.
 func healthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-
 // name, index, temperature.gpu, utilization.gpu,
 // utilization.memory, memory.total, memory.free, memory.used
 func home(w http.ResponseWriter, r *http.Request) {
 
-	metricList := []string {
+	metricList := []string{
 		"temperature.gpu", "utilization.gpu",
 		"utilization.memory", "memory.total", "memory.free", "memory.used"}
 
@@ -61,7 +57,6 @@ func home(w http.ResponseWriter, r *http.Request) {
 	verInfo["Buildtime"] = BuildTime
 	verInfo["Commit"] = Commit
 	verInfo["Release"] = Release
-
 
 	pv := PageVariables{
 		PageTitle:   "Prometheus nVidia GPU Metrics Exporter",
@@ -83,54 +78,50 @@ func home(w http.ResponseWriter, r *http.Request) {
 
 }
 
-
 func metrics(response http.ResponseWriter, request *http.Request) {
-    out, err := exec.Command(
-        "nvidia-smi",
-        "--query-gpu=name,index,temperature.gpu,utilization.gpu,utilization.memory,memory.total,memory.free,memory.used",
-        "--format=csv,noheader,nounits").Output()
+	out, err := exec.Command(
+		"nvidia-smi",
+		"--query-gpu=name,index,temperature.gpu,utilization.gpu,utilization.memory,memory.total,memory.free,memory.used",
+		"--format=csv,noheader,nounits").Output()
 
-    if err != nil {
-        log.Printf("ERROR: %s\n", err)
-        return
-    }
+	if err != nil {
+		log.Printf("ERROR: %s\n", err)
+		return
+	}
 
-    csvReader := csv.NewReader(bytes.NewReader(out))
-    csvReader.TrimLeadingSpace = true
-    records, err := csvReader.ReadAll()
+	csvReader := csv.NewReader(bytes.NewReader(out))
+	csvReader.TrimLeadingSpace = true
+	records, err := csvReader.ReadAll()
 
-    if err != nil {
-        log.Printf("%s\n", err)
-        return
-    }
+	if err != nil {
+		log.Printf("%s\n", err)
+		return
+	}
 
-    metricList := []string {
-        "temperature.gpu", "utilization.gpu",
-        "utilization.memory", "memory.total", "memory.free", "memory.used"}
+	metricList := []string{
+		"temperature.gpu", "utilization.gpu",
+		"utilization.memory", "memory.total", "memory.free", "memory.used"}
 
-    result := ""
-    for _, row := range records {
-        name := fmt.Sprintf("%s[%s]", row[0], row[1])
-        for idx, value := range row[2:] {
-            result = fmt.Sprintf("%s%s{gpu=\"%s\"} %s\n", result, metricList[idx], name, value)
-        }
-    }
+	result := ""
+	for _, row := range records {
+		name := fmt.Sprintf("%s[%s]", row[0], row[1])
+		for idx, value := range row[2:] {
+			result = fmt.Sprintf("%s%s{gpu=\"%s\"} %s\n", result, metricList[idx], name, value)
+		}
+	}
 
-    fmt.Fprintf(response, strings.Replace(result, ".", "_", -1))
+	fmt.Fprintf(response, strings.Replace(result, ".", "_", -1))
 }
 
-
 func main() {
-    log.Print("Starting the service...")
-    port := getEnv("PORT", "9101");
-    addr := ":"+port
+	log.Print("Starting the service...")
+	port := getEnv("PORT", "9101")
+	addr := ":" + port
 
-    log.Print("- PORT set to "+ port +".  If  environment variable PORT is not set the default is 9101")
-
+	log.Print("- PORT set to " + port + ".  If  environment variable PORT is not set the default is 9101")
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
-
 
 	srv := &http.Server{
 		Addr: addr,
@@ -139,7 +130,7 @@ func main() {
 	go func() {
 		http.HandleFunc("/", home)
 		http.HandleFunc("/healthz", healthz)
-		http.HandleFunc("/metrics/", metrics)
+		http.HandleFunc("/metrics", metrics)
 		err := srv.ListenAndServe()
 
 		if err != nil {
@@ -148,7 +139,7 @@ func main() {
 
 	}()
 
-    log.Print("The service is listening on ", port)
+	log.Print("The service is listening on ", port)
 
 	killSignal := <-interrupt
 	switch killSignal {
@@ -161,6 +152,5 @@ func main() {
 	log.Print("The service is shutting down...")
 	srv.Shutdown(context.Background())
 	log.Print("Done")
-
 
 }


### PR DESCRIPTION
Most of prometheus exporters use path /metrics not /metrics/ so proper path should be /metrics, this PR fixes that.

and linting fixes